### PR TITLE
[BUG] Application is not shutting down properly when it is reloaded in watch mode.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,19 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { Logger } from '@nestjs/common';
+import { PrismaService } from './prisma/prisma.service';
 
 const PORT = process.env.PORT || 3001;
 const logger = new Logger();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  const prismaService = app.get(PrismaService);
 
   app.useLogger(app.get(PinoLogger));
   app.flushLogs();
+
+  await prismaService.enableShutdownHooks(app);
   await app.listen(PORT, () => logger.log(`Server is running on port ${PORT}`));
 }
 bootstrap();


### PR DESCRIPTION
When using `Prisma` and `nestjs-pino` together in a project, the following error may occur: `Error: listen EADDRINUSE: address already in use`.

Solution: Refer to the NestJS documentation on issues with `enableShutdownHooks` when using Prisma: https://docs.nestjs.com/recipes/prisma#issues-with-enableshutdownhooks